### PR TITLE
Add in ability to define additional connection options when creating plan

### DIFF
--- a/app/src/main/resources/ui/configuration-data.js
+++ b/app/src/main/resources/ui/configuration-data.js
@@ -1252,3 +1252,22 @@ dataSourcePropertiesMap.set("slack", {
         }
     }
 });
+
+export let subDataSourceConfigMap = new Map();
+subDataSourceConfigMap.set("http", {
+    method: {
+        displayName: "Method",
+        default: "N/A",
+        type: "text",
+        help: "HTTP method.",
+        choice: ["N/A", "GET", "POST", "PUT", "DELETE", "PATCH", "CONNECT", "OPTIONS", "TRACE", "HEAD"],
+        override: "true"
+    },
+    endpoint: {
+        displayName: "Endpoint",
+        default: "",
+        type: "text",
+        help: "Endpoint pathway (i.e. '/my-path/data').",
+        override: "true"
+    }
+});

--- a/app/src/main/resources/ui/configuration-data.js
+++ b/app/src/main/resources/ui/configuration-data.js
@@ -1257,10 +1257,10 @@ export let subDataSourceConfigMap = new Map();
 subDataSourceConfigMap.set("http", {
     method: {
         displayName: "Method",
-        default: "N/A",
+        default: "",
         type: "text",
         help: "HTTP method.",
-        choice: ["N/A", "GET", "POST", "PUT", "DELETE", "PATCH", "CONNECT", "OPTIONS", "TRACE", "HEAD"],
+        choice: ["", "GET", "POST", "PUT", "DELETE", "PATCH", "CONNECT", "OPTIONS", "TRACE", "HEAD"],
         override: "true"
     },
     endpoint: {

--- a/app/src/main/resources/ui/helper-foreign-keys.js
+++ b/app/src/main/resources/ui/helper-foreign-keys.js
@@ -16,6 +16,7 @@ import {
     createInput,
     createSelect,
     createTooltip,
+    dispatchEvent,
     getOverrideConnectionOptionsAsMap,
     wait
 } from "./shared.js";
@@ -50,9 +51,10 @@ async function createForeignKeyLinksFromPlan(newForeignKey, foreignKey, linkType
     for (const fkLink of Array.from(foreignKey[`${linkType}Links`])) {
         let newForeignKeyLink = await createForeignKeyInput(numForeignKeysLinks, `foreign-key-${linkType}-link`);
         foreignKeyLinkSources.insertBefore(newForeignKeyLink, foreignKeyLinkSources.lastChild);
-        $(newForeignKeyLink).find(`select.foreign-key-${linkType}-link`).selectpicker("val", fkLink.taskName)[0].dispatchEvent(new Event("change"));
-        ;
-        $(newForeignKeyLink).find(`input.foreign-key-${linkType}-link`).val(fkLink.columns)[0].dispatchEvent(new Event("input"));
+        let updatedForeignKeyTaskName = $(newForeignKeyLink).find(`select.foreign-key-${linkType}-link`).selectpicker("val", fkLink.taskName);
+        dispatchEvent(updatedForeignKeyTaskName, "change");
+        let updatedForeignKeyColumns = $(newForeignKeyLink).find(`input.foreign-key-${linkType}-link`).val(fkLink.columns);
+        dispatchEvent(updatedForeignKeyColumns, "input");
     }
 }
 
@@ -65,9 +67,10 @@ export async function createForeignKeysFromPlan(respJson) {
             foreignKeysAccordion.append(newForeignKey);
 
             if (foreignKey.source) {
-                $(newForeignKey).find("select.foreign-key-source").selectpicker("val", foreignKey.source.taskName)[0].dispatchEvent(new Event("change"));
-                ;
-                $(newForeignKey).find("input.foreign-key-source").val(foreignKey.source.columns)[0].dispatchEvent(new Event("input"));
+                let updatedTaskName = $(newForeignKey).find("select.foreign-key-source").selectpicker("val", foreignKey.source.taskName);
+                dispatchEvent(updatedTaskName, "change");
+                let updatedColumns = $(newForeignKey).find("input.foreign-key-source").val(foreignKey.source.columns);
+                dispatchEvent(updatedColumns, "input");
             }
 
             if (foreignKey.generationLinks) {
@@ -80,15 +83,15 @@ export async function createForeignKeysFromPlan(respJson) {
     }
 }
 
-function getForeignKeyLinksToArray(fkContainer, className) {
-    let mainContainer = $(fkContainer).find(className);
-    let fkLinks = $(mainContainer).find(".foreign-key-input-container");
-    let fkLinksArray = [];
-    for (let fkLink of fkLinks) {
-        let fkLinkDetails = getForeignKeyDetail(fkLink);
-        fkLinksArray.push(fkLinkDetails);
+function getForeignKeyLinksToArray(foreignKeyContainer, className) {
+    let mainContainer = $(foreignKeyContainer).find(className);
+    let foreignKeyLinks = $(mainContainer).find(".foreign-key-input-container");
+    let foreignKeyLinksArray = [];
+    for (let foreignKeyLink of foreignKeyLinks) {
+        let foreignKeyLinkDetails = getForeignKeyDetail(foreignKeyLink);
+        foreignKeyLinksArray.push(foreignKeyLinkDetails);
     }
-    return fkLinksArray;
+    return foreignKeyLinksArray;
 }
 
 export function getForeignKeys() {

--- a/app/src/main/resources/ui/helper-generation.js
+++ b/app/src/main/resources/ui/helper-generation.js
@@ -6,6 +6,7 @@ import {
     createNewField,
     createSelect,
     createToast,
+    dispatchEvent,
     findNextLevelNodesByClass,
     getDataConnectionsAndAddToSelect,
     wait
@@ -90,8 +91,10 @@ async function createGenerationFields(dataSourceFields, manualSchema) {
         numFields += 1;
         let newField = await createNewField(numFields, "generation");
         $(manualSchema).find(".accordion").first().append(newField);
-        $(newField).find("[id^=field-name]").val(field.name)[0].dispatchEvent(new Event("input"));
-        $(newField).find("select[class~=field-type]").selectpicker("val", field.type)[0].dispatchEvent(new Event("change"));
+        let updatedFieldName = $(newField).find("[id^=field-name]").val(field.name);
+        dispatchEvent(updatedFieldName, "input");
+        let updatedFieldType = $(newField).find("select[class~=field-type]").selectpicker("val", field.type);
+        dispatchEvent(updatedFieldType, "change");
 
         if (field.options) {
             for (const [optKey, optVal] of Object.entries(field.options)) {
@@ -115,7 +118,8 @@ async function createGenerationFields(dataSourceFields, manualSchema) {
 }
 
 async function createAutoGenerationSchema(autoFromMetadataSchema, dataSource) {
-    $(autoFromMetadataSchema).find(".metadata-connection-name").selectpicker("val", dataSource.fields.optMetadataSource.name)[0].dispatchEvent(new Event("change"));
+    let updatedMetadataSource = $(autoFromMetadataSchema).find(".metadata-connection-name").selectpicker("val", dataSource.fields.optMetadataSource.name);
+    dispatchEvent(updatedMetadataSource, "change");
     // takes some time to get the override options
     await wait(100);
     for (let [key, value] of Object.entries(dataSource.fields.optMetadataSource.overrideOptions)) {

--- a/app/src/main/resources/ui/helper-record-count.js
+++ b/app/src/main/resources/ui/helper-record-count.js
@@ -4,7 +4,8 @@ import {
     createFormText,
     createInput,
     createRadioButtons,
-    createSelect
+    createSelect,
+    dispatchEvent
 } from "./shared.js";
 
 
@@ -66,7 +67,8 @@ export function createCountElementsFromPlan(dataSource, newDataSource) {
                 $(newDataSource).find("[id^=per-column-record-count]").val(dsCount.perColumnRecords);
             }
             $(newDataSource).find("[id^=per-column-distribution-select]").selectpicker("val", dsCount.perColumnRecordsDistribution);
-            $(newDataSource).find("[id^=per-column-distribution-select]")[0].dispatchEvent(new Event("change"));
+            let updatedPerColumnDistribution = $(newDataSource).find("[id^=per-column-distribution-select]");
+            dispatchEvent(updatedPerColumnDistribution, "change");
             if (dsCount.perColumnRecordsDistribution === "exponential") {
                 $(newDataSource).find("[id^=per-column-distribution-rate]").val(dsCount.perColumnRecordsDistributionRateParam);
             }

--- a/app/src/main/resources/ui/helper-validation.js
+++ b/app/src/main/resources/ui/helper-validation.js
@@ -14,7 +14,8 @@ import {
     createCloseButton,
     createManualContainer,
     createNewField,
-    findNextLevelNodesByClass
+    dispatchEvent,
+    findNextLevelNodesByClass,
 } from "./shared.js";
 import {validationTypeOptionsMap} from "./configuration-data.js";
 
@@ -25,7 +26,8 @@ export function incValidations() {
 }
 
 function createGroupByValidationFromPlan(newValidation, validationOpts, validation) {
-    $(newValidation).find("[aria-label=GroupByColumns]").val(validationOpts.groupByColumns)[0].dispatchEvent(new Event("input"));
+    let updatedGroupByCols = $(newValidation).find("[aria-label=GroupByColumns]").val(validationOpts.groupByColumns)
+    dispatchEvent(updatedGroupByCols, "input");
     // can be nested validations
 
     if (validation.nested && validation.nested.validations) {
@@ -69,16 +71,19 @@ async function createValidationsFromDataSource(dataSource, manualValidation) {
         numValidations += 1;
         let newValidation = await createNewField(numValidations, "validation");
         $(manualValidation).children(".accordion").append(newValidation);
-        $(newValidation).find("select[class~=validation-type]").selectpicker("val", validation.type)[0].dispatchEvent(new Event("change"));
+        let updatedValidationType = $(newValidation).find("select[class~=validation-type]").selectpicker("val", validation.type);
+        dispatchEvent(updatedValidationType, "change");
         let validationOpts = validation.options;
         let mainContainer = $(newValidation).find("[id^=data-validation-container]")[0];
 
         if (validation.type === "column" && validationOpts.column) {
-            $(newValidation).find("[aria-label=Field]").val(validationOpts.column)[0].dispatchEvent(new Event("input"));
+            let updatedValidationCol = $(newValidation).find("[aria-label=Field]").val(validationOpts.column)
+            dispatchEvent(updatedValidationCol, "input");
         } else if (validation.type === "groupBy" && validationOpts.groupByColumns) {
             createGroupByValidationFromPlan(newValidation, validationOpts, validation);
         } else if (validation.type === "upstream" && validationOpts.upstreamTaskName) {
-            $(newValidation).find("[aria-label=UpstreamTaskName]").val(validationOpts.upstreamTaskName)[0].dispatchEvent(new Event("input"));
+            let updatedUpstreamTaskName = $(newValidation).find("[aria-label=UpstreamTaskName]").val(validationOpts.upstreamTaskName)
+            dispatchEvent(updatedUpstreamTaskName, "input");
             // can be nested validations
 
             if (validation.nested && validation.nested.validations) {

--- a/app/src/main/resources/ui/index.js
+++ b/app/src/main/resources/ui/index.js
@@ -22,6 +22,7 @@ import {
     createManualContainer,
     createSelect,
     createToast,
+    dispatchEvent,
     executePlan,
     getDataConnectionsAndAddToSelect,
     manualContainerDetails,
@@ -400,7 +401,8 @@ if (currUrlParams.includes("plan-name=")) {
                 let newDataSource = await createDataSourceForPlan(numDataSources);
                 tasksDetailsBody.append(newDataSource);
                 $(newDataSource).find(".task-name-field").val(dataSource.taskName);
-                $(newDataSource).find(".data-connection-name").selectpicker("val", dataSource.name)[0].dispatchEvent(new Event("change"));
+                let updatedConnectionName = $(newDataSource).find(".data-connection-name").selectpicker("val", dataSource.name);
+                dispatchEvent(updatedConnectionName, "change");
 
                 await createGenerationElements(dataSource, newDataSource, numDataSources);
                 createCountElementsFromPlan(dataSource, newDataSource);

--- a/app/src/main/resources/ui/index.js
+++ b/app/src/main/resources/ui/index.js
@@ -203,16 +203,17 @@ async function createDataConnectionInput(index) {
     dataConnectionCol.setAttribute("class", "col");
     dataConnectionCol.append(dataConnectionSelect);
 
-    let iconDiv = createIconWithConnectionTooltip(dataConnectionSelect);
+    // provide opportunity to override non-connection options for metadata source (i.e. namespace, dataset)
+    let overrideOptionsContainer = document.createElement("div");
+    let iconDiv = createIconWithConnectionTooltip(dataConnectionSelect, overrideOptionsContainer, "data-source-property", index);
     let iconCol = document.createElement("div");
     iconCol.setAttribute("class", "col-md-auto");
     iconCol.append(iconDiv);
 
-    // let inputGroup = createInputGroup(dataConnectionSelect, iconDiv, "col");
-    // $(inputGroup).find(".input-group").addClass("align-items-center");
     baseTaskDiv.append(taskNameFormFloating, dataConnectionCol, iconCol);
+    let baseDivWithSelectOptions = await getDataConnectionsAndAddToSelect(dataConnectionSelect, baseTaskDiv, "dataSource");
 
-    return await getDataConnectionsAndAddToSelect(dataConnectionSelect, baseTaskDiv, "dataSource");
+    return [baseDivWithSelectOptions, overrideOptionsContainer];
 }
 
 /*
@@ -225,7 +226,7 @@ async function createDataSourceConfiguration(index, closeButton, divider) {
     let divContainer = document.createElement("div");
     divContainer.setAttribute("id", "data-source-config-container-" + index);
     divContainer.setAttribute("class", "data-source-config-container");
-    let dataConnectionFormFloating = await createDataConnectionInput(index);
+    let [dataConnectionFormFloating, overrideConnectionOptionsContainer] = await createDataConnectionInput(index);
     let dataConfigAccordion = document.createElement("div");
     dataConfigAccordion.setAttribute("class", "accordion mt-2");
     let dataGenConfigContainer = createDataConfigElement(index, "generation");
@@ -236,7 +237,7 @@ async function createDataSourceConfiguration(index, closeButton, divider) {
         divContainer.append(divider);
     }
     dataConnectionFormFloating.append(closeButton);
-    divContainer.append(dataConnectionFormFloating, dataConfigAccordion);
+    divContainer.append(dataConnectionFormFloating, overrideConnectionOptionsContainer, dataConfigAccordion);
     return divContainer;
 }
 
@@ -253,6 +254,10 @@ function createReportConfiguration() {
         }
         configOptionsContainer.append(configRow);
     }
+}
+
+function getOverrideConnectionOptions(dataSource, currentDataSource) {
+    currentDataSource["options"] = getOverrideConnectionOptionsAsMap(dataSource, currentDataSource);
 }
 
 createReportConfiguration();
@@ -274,6 +279,7 @@ function getPlanDetails(form) {
         getGeneration(dataSource, currentDataSource);
         getValidations(dataSource, currentDataSource);
         getRecordCount(dataSource, currentDataSource);
+        getOverrideConnectionOptions(dataSource, currentDataSource);
         allUserInputs.push(currentDataSource);
     }
 

--- a/app/src/main/resources/ui/shared.js
+++ b/app/src/main/resources/ui/shared.js
@@ -957,6 +957,14 @@ export function getOverrideConnectionOptionsAsMap(dataSource) {
         }, {});
 }
 
+export function dispatchEvent(findResult, eventType) {
+    if (findResult.length > 0) {
+        findResult[0].dispatchEvent(new Event(eventType));
+    } else {
+        console.log("Failed to dispatch event");
+    }
+}
+
 export const wait = function (ms = 1000) {
     return new Promise(resolve => {
         setTimeout(resolve, ms);

--- a/app/src/main/scala/io/github/datacatering/datacaterer/core/ui/model/JsonSupport.scala
+++ b/app/src/main/scala/io/github/datacatering/datacaterer/core/ui/model/JsonSupport.scala
@@ -31,7 +31,7 @@ trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val waitRequestFormat: RootJsonFormat[WaitRequest] = jsonFormat1(WaitRequest.apply)
   implicit val validationItemRequestsFormat: RootJsonFormat[ValidationItemRequests] = rootFormat(lazyFormat(jsonFormat1(ValidationItemRequests.apply)))
   implicit val validationItemRequestFormat: RootJsonFormat[ValidationItemRequest] = rootFormat(lazyFormat(jsonFormat4(ValidationItemRequest.apply)))
-  implicit val foreignKeyItemRequestFormat: RootJsonFormat[ForeignKeyRequestItem] = jsonFormat2(ForeignKeyRequestItem.apply)
+  implicit val foreignKeyItemRequestFormat: RootJsonFormat[ForeignKeyRequestItem] = jsonFormat3(ForeignKeyRequestItem.apply)
   implicit val foreignKeyRequestFormat: RootJsonFormat[ForeignKeyRequest] = jsonFormat3(ForeignKeyRequest.apply)
   implicit val dataSourceRequestFormat: RootJsonFormat[DataSourceRequest] = jsonFormat7(DataSourceRequest.apply)
   implicit val configurationRequestFormat: RootJsonFormat[ConfigurationRequest] = jsonFormat6(ConfigurationRequest.apply)

--- a/app/src/main/scala/io/github/datacatering/datacaterer/core/ui/model/models.scala
+++ b/app/src/main/scala/io/github/datacatering/datacaterer/core/ui/model/models.scala
@@ -67,7 +67,7 @@ case class ForeignKeyRequest(
                               deleteLinks: List[ForeignKeyRequestItem] = List(),
                             )
 
-case class ForeignKeyRequestItem(taskName: String, columns: String)
+case class ForeignKeyRequestItem(taskName: String, columns: String, options: Option[Map[String, String]] = None)
 
 case class ConfigurationRequest(
                                  flag: Map[String, String] = Map(),

--- a/app/src/main/scala/io/github/datacatering/datacaterer/core/ui/plan/PlanRepository.scala
+++ b/app/src/main/scala/io/github/datacatering/datacaterer/core/ui/plan/PlanRepository.scala
@@ -91,7 +91,8 @@ object PlanRepository extends JsonSupport {
     // get connection info
     val dataSourcesWithConnectionInfo = planRunRequest.dataSources.map(ds => {
       val connectionInfo = ConnectionRepository.getConnection(ds.name, false)
-      ds.copy(`type` = Some(connectionInfo.`type`), options = Some(connectionInfo.options))
+      val allConnectionOptions = connectionInfo.options ++ ds.options.getOrElse(Map())
+      ds.copy(`type` = Some(connectionInfo.`type`), options = Some(allConnectionOptions))
     })
     val planRunWithConnectionInfo = planRunRequest.copy(dataSources = dataSourcesWithConnectionInfo)
     // create new run id

--- a/app/src/main/scala/io/github/datacatering/datacaterer/core/ui/plan/PlanRepository.scala
+++ b/app/src/main/scala/io/github/datacatering/datacaterer/core/ui/plan/PlanRepository.scala
@@ -156,8 +156,16 @@ object PlanRepository extends JsonSupport {
       .asScala
       .map(file => {
         val fileContent = Files.readString(file)
-        fileContent.parseJson.convertTo[PlanRunRequest]
+        val tryParse = Try(fileContent.parseJson.convertTo[PlanRunRequest])
+        tryParse match {
+          case Failure(exception) =>
+            LOGGER.error(s"Failed to parse plan file, file-name=$file, exception=${exception.getMessage}")
+            None
+          case Success(value) => Some(value)
+        }
       })
+      .filter(_.isDefined)
+      .map(_.get)
       .toList
     PlanRunRequests(plans)
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 groupId=io.github.data-catering
-version=0.9.1
+version=0.9.2
 
 scalaVersion=2.12
 scalaSpecificVersion=2.12.15


### PR DESCRIPTION
Users can re-use connection information when creating plan details. It can be used for data generation, validation and relationship definitions.